### PR TITLE
Fix namespace typo 'PHPunit' to 'PHPUnit'

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Once installed, add the following attributes to the `<phpunit>` element in your
 `phpunit.xml` file:
 
     printerFile="vendor/whatthejeff/nyancat-phpunit-resultprinter/src/NyanCat/PHPUnit/ResultPrinter.php"
-    printerClass="NyanCat\PHPunit\ResultPrinter"
+    printerClass="NyanCat\PHPUnit\ResultPrinter"
 
 ## Tests
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,7 +7,7 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          printerFile="src/NyanCat/PHPUnit/ResultPrinter.php"
-         printerClass="NyanCat\PHPunit\ResultPrinter"
+         printerClass="NyanCat\PHPUnit\ResultPrinter"
          processIsolation="false"
          stopOnFailure="false"
          syntaxCheck="false"

--- a/src/NyanCat/PHPUnit/ResultPrinter.php
+++ b/src/NyanCat/PHPUnit/ResultPrinter.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace NyanCat\PHPunit;
+namespace NyanCat\PHPUnit;
 
 use NyanCat\Cat;
 use NyanCat\Rainbow;

--- a/tests/NyanCat/PHPUnit/Tests/_files/phpunit.xml
+++ b/tests/NyanCat/PHPUnit/Tests/_files/phpunit.xml
@@ -6,7 +6,7 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          printerFile="../../../../../src/NyanCat/PHPUnit/ResultPrinter.php"
-         printerClass="NyanCat\PHPunit\ResultPrinter"
+         printerClass="NyanCat\PHPUnit\ResultPrinter"
          processIsolation="false"
          stopOnFailure="false"
          syntaxCheck="false"


### PR DESCRIPTION
This path of `ResultPrinter.php` is src/NyanCat/PHP<strong>Unit</strong>/ResultPrinter.php

but namespace and config specification is PHP<strong>unit</strong>

Hope to fix along [PSR-0](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-0.md)
