### PR TITLE
Fix namespace ref

### DIFF
--- a/src/NyanCat/PHPUnit/ResultPrinter.php
+++ b/src/NyanCat/PHPUnit/ResultPrinter.php
@@ -33,7 +33,7 @@ class ResultPrinter extends \PHPUnit_TextUI_ResultPrinter
     /**
      * The Nyan Cat scoreboard.
      *
-     * @var NyanCat\Scoreboard
+     * @var \NyanCat\Scoreboard
      */
     private $scoreboard;
 


### PR DESCRIPTION
This should so totally be the default test runner printer! You win one free interwebs for writing it.

![winternet](https://cloud.githubusercontent.com/assets/146040/2863969/34a357d6-d20b-11e3-84eb-72caa7b8b0ba.jpg)
