### PR TITLE
Add support for PHPUnit 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,8 @@
 language: php
 
 php:
-    - 5.3.3
-    - 5.3
-    - 5.4
-    - 5.5
-    - 5.6
-    - hhvm
+    - 7.0
+    - 7.1
 
 before_script:
     - composer install --prefer-source

--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,11 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=7.0",
         "whatthejeff/nyancat-scoreboard": "~1.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.2"
+        "phpunit/phpunit": "~6.0"
     },
     "autoload": {
         "psr-0": {

--- a/src/NyanCat/PHPUnit/ResultPrinter.php
+++ b/src/NyanCat/PHPUnit/ResultPrinter.php
@@ -44,7 +44,7 @@ class ResultPrinter extends \PHPUnit\TextUI\ResultPrinter
     /**
      * {@inheritdoc}
      */
-    public function __construct($out = NULL, $verbose = FALSE, $colors = FALSE, $debug = FALSE)
+    public function __construct($out = NULL, $verbose = FALSE, $colors = self::COLOR_DEFAULT, $debug = FALSE, $numberOfColumns = 80, $reverse = false)
     {
         $this->scoreboard = new Scoreboard(
             new Cat(),
@@ -62,7 +62,7 @@ class ResultPrinter extends \PHPUnit\TextUI\ResultPrinter
             array($this, 'write')
         );
 
-        parent::__construct($out, $verbose, true, $debug);
+        parent::__construct($out, $verbose, self::COLOR_ALWAYS, $debug);
     }
 
     /**

--- a/src/NyanCat/PHPUnit/ResultPrinter.php
+++ b/src/NyanCat/PHPUnit/ResultPrinter.php
@@ -17,6 +17,10 @@ use NyanCat\Team;
 use NyanCat\Scoreboard;
 
 use Fab\Factory as FabFactory;
+use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Test;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestSuite;
 
 /**
  * Mmmm poptarts...
@@ -28,7 +32,7 @@ use Fab\Factory as FabFactory;
  *
  * @author Jeff Welch <whatthejeff@gmail.com>
  */
-class ResultPrinter extends \PHPUnit_TextUI_ResultPrinter
+class ResultPrinter extends \PHPUnit\TextUI\ResultPrinter
 {
     /**
      * The Nyan Cat scoreboard.
@@ -91,7 +95,7 @@ class ResultPrinter extends \PHPUnit_TextUI_ResultPrinter
     /**
      * {@inheritdoc}
      */
-    public function addError(\PHPUnit_Framework_Test $test, \Exception $e, $time)
+    public function addError(Test $test, \Exception $e, $time)
     {
         if ($this->debug) {
             return parent::addError($test, $e, $time);
@@ -104,7 +108,7 @@ class ResultPrinter extends \PHPUnit_TextUI_ResultPrinter
     /**
      * {@inheritdoc}
      */
-    public function addFailure(\PHPUnit_Framework_Test $test, \PHPUnit_Framework_AssertionFailedError $e, $time)
+    public function addFailure(Test $test, AssertionFailedError $e, $time)
     {
         if ($this->debug) {
             return parent::addFailure($test, $e, $time);
@@ -117,7 +121,7 @@ class ResultPrinter extends \PHPUnit_TextUI_ResultPrinter
     /**
      * {@inheritdoc}
      */
-    public function addIncompleteTest(\PHPUnit_Framework_Test $test, \Exception $e, $time)
+    public function addIncompleteTest(Test $test, \Exception $e, $time)
     {
         if ($this->debug) {
             return parent::addIncompleteTest($test, $e, $time);
@@ -130,7 +134,7 @@ class ResultPrinter extends \PHPUnit_TextUI_ResultPrinter
     /**
      * {@inheritdoc}
      */
-    public function addSkippedTest(\PHPUnit_Framework_Test $test, \Exception $e, $time)
+    public function addSkippedTest(Test $test, \Exception $e, $time)
     {
         if ($this->debug) {
             return parent::addSkippedTest($test, $e, $time);
@@ -143,7 +147,7 @@ class ResultPrinter extends \PHPUnit_TextUI_ResultPrinter
     /**
      * {@inheritdoc}
      */
-    public function startTestSuite(\PHPUnit_Framework_TestSuite $suite)
+    public function startTestSuite(TestSuite $suite)
     {
         if ($this->debug) {
             return parent::startTestSuite($suite);
@@ -158,7 +162,7 @@ class ResultPrinter extends \PHPUnit_TextUI_ResultPrinter
     /**
      * {@inheritdoc}
      */
-    public function endTest(\PHPUnit_Framework_Test $test, $time)
+    public function endTest(Test $test, $time)
     {
         if ($this->debug) {
             return parent::endTest($test, $time);
@@ -168,12 +172,8 @@ class ResultPrinter extends \PHPUnit_TextUI_ResultPrinter
             $this->writeProgress('pass');
         }
 
-        if ($test instanceof \PHPUnit_Framework_TestCase) {
+        if ($test instanceof TestCase) {
             $this->numAssertions += $test->getNumAssertions();
-        }
-
-        else if ($test instanceof \PHPUnit_Extensions_PhptTestCase) {
-            $this->numAssertions++;
         }
 
         $this->lastTestFailed = FALSE;

--- a/tests/NyanCat/PHPUnit/Tests/_files/ResultPrinterTest.php
+++ b/tests/NyanCat/PHPUnit/Tests/_files/ResultPrinterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-    class ResultPrinterTest extends PHPUnit_Framework_TestCase
+    class ResultPrinterTest extends PHPUnit\Framework\TestCase
     {
         public function testSuccess()
         {

--- a/tests/NyanCat/PHPUnit/Tests/debug.phpt
+++ b/tests/NyanCat/PHPUnit/Tests/debug.phpt
@@ -12,9 +12,7 @@ require_once dirname(dirname(dirname(dirname(dirname(__FILE__))))) . '/vendor/au
 PHPUnit\TextUI\Command::main();
 ?>
 --EXPECTF--
-PHPUnit %s by Sebastian Bergmann.
-
-Configuration read from %a
+PHPUnit %s by Sebastian Bergmann and contributors.
 
 
 Starting test 'ResultPrinterTest::testSuccess'.
@@ -26,9 +24,9 @@ Starting test 'ResultPrinterTest::testError'.
 Starting test 'ResultPrinterTest::testSkipped'.
 [36;1mS[0m
 Starting test 'ResultPrinterTest::testIncomplete'.
-[33;1mI[0m
+[33;1mI[0m                                                               5 / 5 (100%)
 
-Time: %s, Memory: %sMb
+Time: %s, Memory: %s
 
 There was 1 error:
 
@@ -45,7 +43,6 @@ There was 1 failure:
 Failed asserting that false is true.
 
 %s:%i
-[37;41m                                                                           [0m
-[37;41mFAILURES!                                                                  [0m
-[37;41mTests: 5, Assertions: 2, Failures: 1, Errors: 1, Incomplete: 1, Skipped: 1.[0m
 
+[37;41mERRORS![0m
+[37;41mTests: 5[0m[37;41m, Assertions: 2[0m[37;41m, Errors: 1[0m[37;41m, Failures: 1[0m[37;41m, Skipped: 1[0m[37;41m, Incomplete: 1[0m[37;41m.[0m

--- a/tests/NyanCat/PHPUnit/Tests/debug.phpt
+++ b/tests/NyanCat/PHPUnit/Tests/debug.phpt
@@ -9,7 +9,7 @@ $_SERVER['argv'][3] = dirname(__FILE__) . '/_files/phpunit.xml';
 $_SERVER['argv'][4] = dirname(__FILE__) . '/_files/ResultPrinterTest.php';
 
 require_once dirname(dirname(dirname(dirname(dirname(__FILE__))))) . '/vendor/autoload.php';
-PHPUnit_TextUI_Command::main();
+PHPUnit\TextUI\Command::main();
 ?>
 --EXPECTF--
 PHPUnit %s by Sebastian Bergmann.

--- a/tests/NyanCat/PHPUnit/Tests/few-tests-fab.phpt
+++ b/tests/NyanCat/PHPUnit/Tests/few-tests-fab.phpt
@@ -11,9 +11,7 @@ require_once dirname(dirname(dirname(dirname(dirname(__FILE__))))) . '/vendor/au
 PHPUnit\TextUI\Command::main();
 ?>
 --EXPECTF--
-PHPUnit %s by Sebastian Bergmann.
-
-Configuration read from %a
+PHPUnit %s by Sebastian Bergmann and contributors.
 
  [32m0[0m
  [31m0[0m
@@ -93,7 +91,7 @@ Configuration read from %a
  
 
 
-Time: %s, Memory: %sMb
+Time: %s, Memory: %s
 
 There was 1 error:
 
@@ -110,7 +108,6 @@ There was 1 failure:
 Failed asserting that false is true.
 
 %s:%i
-[37;41m                                                                           [0m
-[37;41mFAILURES!                                                                  [0m
-[37;41mTests: 5, Assertions: 2, Failures: 1, Errors: 1, Incomplete: 1, Skipped: 1.[0m
 
+[37;41mERRORS![0m
+[37;41mTests: 5[0m[37;41m, Assertions: 2[0m[37;41m, Errors: 1[0m[37;41m, Failures: 1[0m[37;41m, Skipped: 1[0m[37;41m, Incomplete: 1[0m[37;41m.[0m

--- a/tests/NyanCat/PHPUnit/Tests/few-tests-fab.phpt
+++ b/tests/NyanCat/PHPUnit/Tests/few-tests-fab.phpt
@@ -8,7 +8,7 @@ $_SERVER['argv'][2] = dirname(__FILE__) . '/_files/phpunit.xml';
 $_SERVER['argv'][3] = dirname(__FILE__) . '/_files/ResultPrinterTest.php';
 
 require_once dirname(dirname(dirname(dirname(dirname(__FILE__))))) . '/vendor/autoload.php';
-PHPUnit_TextUI_Command::main();
+PHPUnit\TextUI\Command::main();
 ?>
 --EXPECTF--
 PHPUnit %s by Sebastian Bergmann.

--- a/tests/NyanCat/PHPUnit/Tests/few-tests-superfab.phpt
+++ b/tests/NyanCat/PHPUnit/Tests/few-tests-superfab.phpt
@@ -11,9 +11,7 @@ require_once dirname(dirname(dirname(dirname(dirname(__FILE__))))) . '/vendor/au
 PHPUnit\TextUI\Command::main();
 ?>
 --EXPECTF--
-PHPUnit %s by Sebastian Bergmann.
-
-Configuration read from %a
+PHPUnit %s by Sebastian Bergmann and contributors.
 
  [32m0[0m
  [31m0[0m
@@ -93,7 +91,7 @@ Configuration read from %a
  
 
 
-Time: %s, Memory: %sMb
+Time: %s, Memory: %s
 
 There was 1 error:
 
@@ -110,7 +108,6 @@ There was 1 failure:
 Failed asserting that false is true.
 
 %s:%i
-[37;41m                                                                           [0m
-[37;41mFAILURES!                                                                  [0m
-[37;41mTests: 5, Assertions: 2, Failures: 1, Errors: 1, Incomplete: 1, Skipped: 1.[0m
 
+[37;41mERRORS![0m
+[37;41mTests: 5[0m[37;41m, Assertions: 2[0m[37;41m, Errors: 1[0m[37;41m, Failures: 1[0m[37;41m, Skipped: 1[0m[37;41m, Incomplete: 1[0m[37;41m.[0m

--- a/tests/NyanCat/PHPUnit/Tests/few-tests-superfab.phpt
+++ b/tests/NyanCat/PHPUnit/Tests/few-tests-superfab.phpt
@@ -8,7 +8,7 @@ $_SERVER['argv'][2] = dirname(__FILE__) . '/_files/phpunit.xml';
 $_SERVER['argv'][3] = dirname(__FILE__) . '/_files/ResultPrinterTest.php';
 
 require_once dirname(dirname(dirname(dirname(dirname(__FILE__))))) . '/vendor/autoload.php';
-PHPUnit_TextUI_Command::main();
+PHPUnit\TextUI\Command::main();
 ?>
 --EXPECTF--
 PHPUnit %s by Sebastian Bergmann.

--- a/tests/NyanCat/PHPUnit/Tests/lots-of-tests-fab.phpt
+++ b/tests/NyanCat/PHPUnit/Tests/lots-of-tests-fab.phpt
@@ -13,9 +13,7 @@ require_once dirname(dirname(dirname(dirname(dirname(__FILE__))))) . '/vendor/au
 PHPUnit\TextUI\Command::main();
 ?>
 --EXPECTF--
-PHPUnit %s by Sebastian Bergmann.
-
-Configuration read from %a
+PHPUnit %s by Sebastian Bergmann and contributors.
 
  [32m0[0m
  [31m0[0m
@@ -335,7 +333,7 @@ Configuration read from %a
  
 
 
-Time: %s, Memory: %sMb
+Time: %s, Memory: %s
 
 There were 5 errors:
 
@@ -392,6 +390,6 @@ Failed asserting that false is true.
 Failed asserting that false is true.
 
 %s:%i
-[37;41m                                                                             [0m
-[37;41mFAILURES!                                                                    [0m
-[37;41mTests: 25, Assertions: 10, Failures: 5, Errors: 5, Incomplete: 5, Skipped: 5.[0m
+
+[37;41mERRORS![0m
+[37;41mTests: 25[0m[37;41m, Assertions: 10[0m[37;41m, Errors: 5[0m[37;41m, Failures: 5[0m[37;41m, Skipped: 5[0m[37;41m, Incomplete: 5[0m[37;41m.[0m

--- a/tests/NyanCat/PHPUnit/Tests/lots-of-tests-fab.phpt
+++ b/tests/NyanCat/PHPUnit/Tests/lots-of-tests-fab.phpt
@@ -10,7 +10,7 @@ $_SERVER['argv'][4] = '5';
 $_SERVER['argv'][5] = dirname(__FILE__) . '/_files/ResultPrinterTest.php';
 
 require_once dirname(dirname(dirname(dirname(dirname(__FILE__))))) . '/vendor/autoload.php';
-PHPUnit_TextUI_Command::main();
+PHPUnit\TextUI\Command::main();
 ?>
 --EXPECTF--
 PHPUnit %s by Sebastian Bergmann.

--- a/tests/NyanCat/PHPUnit/Tests/lots-of-tests-superfab.phpt
+++ b/tests/NyanCat/PHPUnit/Tests/lots-of-tests-superfab.phpt
@@ -13,9 +13,7 @@ require_once dirname(dirname(dirname(dirname(dirname(__FILE__))))) . '/vendor/au
 PHPUnit\TextUI\Command::main();
 ?>
 --EXPECTF--
-PHPUnit %s by Sebastian Bergmann.
-
-Configuration read from %a
+PHPUnit %s by Sebastian Bergmann and contributors.
 
  [32m0[0m
  [31m0[0m
@@ -335,7 +333,7 @@ Configuration read from %a
  
 
 
-Time: %s, Memory: %sMb
+Time: %s ms, Memory: %sMB
 
 There were 5 errors:
 
@@ -392,7 +390,6 @@ Failed asserting that false is true.
 Failed asserting that false is true.
 
 %s:%i
-[37;41m                                                                             [0m
-[37;41mFAILURES!                                                                    [0m
-[37;41mTests: 25, Assertions: 10, Failures: 5, Errors: 5, Incomplete: 5, Skipped: 5.[0m
 
+[37;41mERRORS![0m
+[37;41mTests: 25[0m[37;41m, Assertions: 10[0m[37;41m, Errors: 5[0m[37;41m, Failures: 5[0m[37;41m, Skipped: 5[0m[37;41m, Incomplete: 5[0m[37;41m.[0m

--- a/tests/NyanCat/PHPUnit/Tests/lots-of-tests-superfab.phpt
+++ b/tests/NyanCat/PHPUnit/Tests/lots-of-tests-superfab.phpt
@@ -10,7 +10,7 @@ $_SERVER['argv'][4] = '5';
 $_SERVER['argv'][5] = dirname(__FILE__) . '/_files/ResultPrinterTest.php';
 
 require_once dirname(dirname(dirname(dirname(dirname(__FILE__))))) . '/vendor/autoload.php';
-PHPUnit_TextUI_Command::main();
+PHPUnit\TextUI\Command::main();
 ?>
 --EXPECTF--
 PHPUnit %s by Sebastian Bergmann.

--- a/tests/NyanCat/PHPUnit/Tests/no-tests-fab.phpt
+++ b/tests/NyanCat/PHPUnit/Tests/no-tests-fab.phpt
@@ -13,9 +13,7 @@ require_once dirname(dirname(dirname(dirname(dirname(__FILE__))))) . '/vendor/au
 PHPUnit\TextUI\Command::main();
 ?>
 --EXPECTF--
-PHPUnit %s by Sebastian Bergmann.
-
-Configuration read from %a
+PHPUnit %s by Sebastian Bergmann and contributors.
 
  [32m0[0m
  [31m0[0m
@@ -35,6 +33,6 @@ Configuration read from %a
  
 
 
-Time: %s, Memory: %sMb
+Time: %s, Memory: %s
 
-[30;43mNo tests executed![0m
+[30;43mNo tests executed!%s

--- a/tests/NyanCat/PHPUnit/Tests/no-tests-fab.phpt
+++ b/tests/NyanCat/PHPUnit/Tests/no-tests-fab.phpt
@@ -10,7 +10,7 @@ $_SERVER['argv'][4] = 'notests';
 $_SERVER['argv'][5] = dirname(__FILE__) . '/_files/ResultPrinterTest.php';
 
 require_once dirname(dirname(dirname(dirname(dirname(__FILE__))))) . '/vendor/autoload.php';
-PHPUnit_TextUI_Command::main();
+PHPUnit\TextUI\Command::main();
 ?>
 --EXPECTF--
 PHPUnit %s by Sebastian Bergmann.

--- a/tests/NyanCat/PHPUnit/Tests/no-tests-superfab.phpt
+++ b/tests/NyanCat/PHPUnit/Tests/no-tests-superfab.phpt
@@ -10,7 +10,7 @@ $_SERVER['argv'][4] = 'notests';
 $_SERVER['argv'][5] = dirname(__FILE__) . '/_files/ResultPrinterTest.php';
 
 require_once dirname(dirname(dirname(dirname(dirname(__FILE__))))) . '/vendor/autoload.php';
-PHPUnit_TextUI_Command::main();
+PHPUnit\TextUI\Command::main();
 ?>
 --EXPECTF--
 PHPUnit %s by Sebastian Bergmann.

--- a/tests/NyanCat/PHPUnit/Tests/no-tests-superfab.phpt
+++ b/tests/NyanCat/PHPUnit/Tests/no-tests-superfab.phpt
@@ -13,9 +13,7 @@ require_once dirname(dirname(dirname(dirname(dirname(__FILE__))))) . '/vendor/au
 PHPUnit\TextUI\Command::main();
 ?>
 --EXPECTF--
-PHPUnit %s by Sebastian Bergmann.
-
-Configuration read from %a
+PHPUnit %s by Sebastian Bergmann and contributors.
 
  [32m0[0m
  [31m0[0m
@@ -35,6 +33,6 @@ Configuration read from %a
  
 
 
-Time: %s, Memory: %sMb
+Time: %s, Memory: %s
 
 [30;43mNo tests executed![0m


### PR DESCRIPTION
Thank you @JeroenDeDauw for beginning the work to add PHPUnit 6 support in #11. I continued work to finish adding support.

This PR allows this library to run against PHPUnit 6+ (and PHP 7.0+ which is required by PHPUnit 6.)

* Updated `NyanCat/PHPUnit/ResultPrinter::__construct()` arguments for PHPUnit 6
* Fixed test output to match PHPUnit core ResultPrinter changes

Suggest tagging version `v1.3.0` because of the new dependency version requirements.

![screen shot 2017-07-03 at 12 20 33 pm](https://user-images.githubusercontent.com/135607/27802555-0d3d6054-5fea-11e7-902b-3b0d30eaf466.png)