### PR TITLE
Make result printer compatible with phpUnit version 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ sudo: false
 dist: trusty
 
 php:
-  - 7.0
   - 7.1
+  - 7.2
   - nightly
 
 before_script:

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "whatthejeff/nyancat-scoreboard": "~1.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.5"
+        "phpunit/phpunit": "^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,7 +10,6 @@
          printerClass="NyanCat\PHPUnit\ResultPrinter"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          bootstrap="vendor/autoload.php"
 >
     <testsuites>

--- a/src/NyanCat/PHPUnit/ResultPrinter.php
+++ b/src/NyanCat/PHPUnit/ResultPrinter.php
@@ -68,7 +68,7 @@ class ResultPrinter extends \PHPUnit\TextUI\ResultPrinter
     /**
      * {@inheritdoc}
      */
-    protected function writeProgress($progress): void
+    protected function writeProgress(string $progress): void
     {
         if($this->debug) {
             parent::writeProgress($progress);

--- a/src/NyanCat/PHPUnit/ResultPrinter.php
+++ b/src/NyanCat/PHPUnit/ResultPrinter.php
@@ -68,10 +68,11 @@ class ResultPrinter extends \PHPUnit\TextUI\ResultPrinter
     /**
      * {@inheritdoc}
      */
-    protected function writeProgress($progress)
+    protected function writeProgress($progress): void
     {
         if($this->debug) {
-            return parent::writeProgress($progress);
+            parent::writeProgress($progress);
+            return ;
         }
 
         $this->scoreboard->score($progress);
@@ -80,7 +81,7 @@ class ResultPrinter extends \PHPUnit\TextUI\ResultPrinter
     /**
      * {@inheritdoc}
      */
-    protected function printHeader()
+    protected function printHeader(): void
     {
         if (!$this->debug) {
             if (!$this->scoreboard->isRunning()) {
@@ -95,10 +96,11 @@ class ResultPrinter extends \PHPUnit\TextUI\ResultPrinter
     /**
      * {@inheritdoc}
      */
-    public function addError(Test $test, \Exception $e, $time)
+    public function addError(Test $test, \Throwable $e, float $time): void
     {
         if ($this->debug) {
-            return parent::addError($test, $e, $time);
+            parent::addError($test, $e, $time);
+            return ;
         }
 
         $this->writeProgress('fail');
@@ -108,10 +110,11 @@ class ResultPrinter extends \PHPUnit\TextUI\ResultPrinter
     /**
      * {@inheritdoc}
      */
-    public function addFailure(Test $test, AssertionFailedError $e, $time)
+    public function addFailure(Test $test, AssertionFailedError $e, float $time): void
     {
         if ($this->debug) {
-            return parent::addFailure($test, $e, $time);
+            parent::addFailure($test, $e, $time);
+            return ;
         }
 
         $this->writeProgress('fail');
@@ -121,10 +124,11 @@ class ResultPrinter extends \PHPUnit\TextUI\ResultPrinter
     /**
      * {@inheritdoc}
      */
-    public function addIncompleteTest(Test $test, \Exception $e, $time)
+    public function addIncompleteTest(Test $test, \Throwable $e, float $time): void
     {
         if ($this->debug) {
-            return parent::addIncompleteTest($test, $e, $time);
+            parent::addIncompleteTest($test, $e, $time);
+            return ;
         }
 
         $this->writeProgress('pending');
@@ -134,10 +138,11 @@ class ResultPrinter extends \PHPUnit\TextUI\ResultPrinter
     /**
      * {@inheritdoc}
      */
-    public function addSkippedTest(Test $test, \Exception $e, $time)
+    public function addSkippedTest(Test $test, \Throwable $e, float $time): void
     {
         if ($this->debug) {
-            return parent::addSkippedTest($test, $e, $time);
+            parent::addSkippedTest($test, $e, $time);
+            return ;
         }
 
         $this->writeProgress('pending');
@@ -147,10 +152,11 @@ class ResultPrinter extends \PHPUnit\TextUI\ResultPrinter
     /**
      * {@inheritdoc}
      */
-    public function startTestSuite(TestSuite $suite)
+    public function startTestSuite(TestSuite $suite): void
     {
         if ($this->debug) {
-            return parent::startTestSuite($suite);
+            parent::startTestSuite($suite);
+            return ;
         }
 
         if ($this->numTests == -1) {
@@ -162,10 +168,11 @@ class ResultPrinter extends \PHPUnit\TextUI\ResultPrinter
     /**
      * {@inheritdoc}
      */
-    public function endTest(Test $test, $time)
+    public function endTest(Test $test, float $time): void
     {
         if ($this->debug) {
-            return parent::endTest($test, $time);
+            parent::endTest($test, $time);
+            return ;
         }
 
         if (!$this->lastTestFailed) {

--- a/tests/NyanCat/PHPUnit/Tests/_files/phpunit.xml
+++ b/tests/NyanCat/PHPUnit/Tests/_files/phpunit.xml
@@ -9,7 +9,6 @@
          printerClass="NyanCat\PHPUnit\ResultPrinter"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          bootstrap="../../../../../vendor/autoload.php"
 >
 


### PR DESCRIPTION
 - Fixed parameter type hinting
 - Fixed void returns
 - Updated composer settings
 - Updated phpunit xml config to v7